### PR TITLE
Update assertion in `property` function

### DIFF
--- a/src/pluginscript_class_metadata.lua
+++ b/src/pluginscript_class_metadata.lua
@@ -162,7 +162,7 @@ function property(metadata)
 		end
 		prop.setter = setter
 	end
-	assert(default_value ~= nil or property_type ~= VariantType.Nil or getter == nil, "Expected either default value, type or getter")
+	assert(default_value ~= nil or property_type ~= VariantType.Nil or getter ~= nil, "Expected either default value, type or getter for property")
 	prop.default_value = default_value
 	prop.type = property_type
 	prop.getter = getter


### PR DESCRIPTION
I believe the assertion in the `property` function should be using `~=` for `getter`. Currently it is allowing the following calls without an assertion being raised:
```lua
property()
property({})
```
I also added "for property" to the error message since the stacktrace doesn't help you know where the issue is coming from since it gives you a line into the bundled amalgamated source. "for property" is maybe not the best wording but I think it helps.