### PR TITLE
Fix string split calls

### DIFF
--- a/src/godot_string.lua
+++ b/src/godot_string.lua
@@ -326,9 +326,11 @@ local methods = {
 	split_floats = function(self, splitter, allow_empty)
 		allow_empty = allow_empty == nil or allow_empty
 		if ffi_istype(Array, splitter) then
-			return ffi_gc(api.godot_string_split_floats_mk_allows_empty(self, splitter, allow_empty), api.godot_array_destroy)
+			local split_floats_method = allow_empty and api.godot_string_split_floats_mk_allows_empty or api.godot_string_split_floats_mk
+			return ffi_gc(split_floats_method(self, splitter), api.godot_array_destroy)
 		else
-			return ffi_gc(api.godot_string_split_floats_allows_empty(self, str(splitter), allow_empty), api.godot_array_destroy)
+			local split_floats_method = allow_empty and api.godot_string_split_floats_allows_empty or api.godot_string_split_floats
+			return ffi_gc(split_floats_method(self, str(splitter)), api.godot_array_destroy)
 		end
 	end,
 	--- Splits the String in integers by using a delimiter string and returns an array of integers.
@@ -339,9 +341,11 @@ local methods = {
 	split_ints = function(self, splitter, allow_empty)
 		allow_empty = allow_empty == nil or allow_empty
 		if ffi_istype(Array, splitter) then
-			return ffi_gc(api.godot_string_split_ints_mk_allows_empty(self, splitter, allow_empty), api.godot_array_destroy)
+			local split_ints_method = allow_empty and api.godot_string_split_ints_mk_allows_empty or api.godot_string_split_ints_mk
+			return ffi_gc(split_ints_method(self, splitter), api.godot_array_destroy)
 		else
-			return ffi_gc(api.godot_string_split_ints_allows_empty(self, str(splitter), allow_empty), api.godot_array_destroy)
+			local split_ints_method = allow_empty and api.godot_string_split_ints_allows_empty or api.godot_string_split_ints
+			return ffi_gc(split_ints_method(self, str(splitter)), api.godot_array_destroy)
 		end
 	end,
 	--- Splits the String by whitespace and returns an array of the substrings.

--- a/src/godot_string.lua
+++ b/src/godot_string.lua
@@ -314,7 +314,12 @@ local methods = {
 	-- @param[opt=true] allow_empty  If absent or truthy, inserts empty substrings in the resulting Array
 	-- @treturn String
 	split = function(self, splitter, allow_empty)
-		return ffi_gc(api.godot_string_split_allow_empty(self, str(splitter), allow_empty == nil or allow_empty), api.godot_array_destroy)
+		allow_empty = allow_empty == nil or allow_empty
+		if allow_empty then
+			return ffi_gc(api.godot_string_split_allow_empty(self, str(splitter)), api.godot_array_destroy)
+		else
+			return ffi_gc(api.godot_string_split(self, str(splitter)), api.godot_array_destroy)
+		end
 	end,
 	--- Splits the String in numbers by using a delimiter and returns an array of reals.
 	-- @function split_floats

--- a/src/godot_string.lua
+++ b/src/godot_string.lua
@@ -315,11 +315,8 @@ local methods = {
 	-- @treturn String
 	split = function(self, splitter, allow_empty)
 		allow_empty = allow_empty == nil or allow_empty
-		if allow_empty then
-			return ffi_gc(api.godot_string_split_allow_empty(self, str(splitter)), api.godot_array_destroy)
-		else
-			return ffi_gc(api.godot_string_split(self, str(splitter)), api.godot_array_destroy)
-		end
+		local string_split_method = allow_empty and api.godot_string_split_allow_empty or api.godot_string_split
+		return ffi_gc(string_split_method(self, str(splitter)), api.godot_array_destroy)
 	end,
 	--- Splits the String in numbers by using a delimiter and returns an array of reals.
 	-- @function split_floats


### PR DESCRIPTION
When using string's split method, I received an error about the wrong number of arguments. After a quick look at GDNative's API calls for string split, it appears that the there are two methods: one for "allow empty" and one without it. I modified the call to account for this.