### PR TITLE
Remove need for exported hgdn symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [Unreleased](https://github.com/gilzoide/godot-lua-pluginscript/compare/0.5.0...HEAD)
 ### Fixed
 
+- Plugin initialization on Windows ([#31](https://github.com/gilzoide/godot-lua-pluginscript/issues/31))
 - [build] Fixed `make dist` dependencies to include LuaJIT's `jit/*.lua` files
 - [build] Fixed `make unzip-to-build` to only copy contents from `build` folder
 

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,6 @@ build/%/liblua_pluginscript.so: $(BUILT_OBJS) build/%/luajit/src/libluajit.a
 
 build/%/lua_pluginscript.dll: TARGET_SYS = Windows
 build/%/lua_pluginscript.dll: EXE = .exe
-build/%/lua_pluginscript.dll: CFLAGS += -DLUAJIT_DYNAMICALLY_LINKED
 build/%/lua_pluginscript.dll: $(BUILT_OBJS) build/%/lua51.dll
 	$(_CC) -o $@ $^ -shared $(CFLAGS) $(LDFLAGS)
 	$(call STRIP_CMD,$@)

--- a/src/cache_lua_libs.lua
+++ b/src/cache_lua_libs.lua
@@ -54,6 +54,7 @@ local setthreadfunc, touserdata
 -- FFI
 local ffi_cast, ffi_cdef, ffi_copy, ffi_gc, ffi_istype, ffi_metatype, ffi_new, ffi_sizeof, ffi_string, ffi_typeof
     = ffi.cast, ffi.cdef, ffi.copy, ffi.gc, ffi.istype, ffi.metatype, ffi.new, ffi.sizeof, ffi.string, ffi.typeof
+local clib = ffi.C
 
 -- Weak tables
 local weak_kv = { __mode = 'kv' }

--- a/src/godot_basis.lua
+++ b/src/godot_basis.lua
@@ -170,7 +170,7 @@ methods.FLIP_Z = ffi_new('godot_basis', { elements = { 1, 0, 0, 0, 1, 0, 0, 0, -
 
 --- Metamethods
 -- @section metamethods
-Basis = ffi.metatype('godot_basis', {
+Basis = ffi_metatype('godot_basis', {
 	--- Basis constructor, called by the idiom `Basis(...)`.
 	--
 	-- * `Basis()`: `IDENTITY` basis matrix

--- a/src/godot_class.lua
+++ b/src/godot_class.lua
@@ -171,7 +171,7 @@ local ClassWrapper_cache = setmetatable({}, {
 --- MethodBind metatype, wrapper for `godot_method_bind`.
 -- These are returned by `ClassWrapper:__index` and GDNative's `godot_method_bind_get_method`.
 -- @type MethodBind
-local MethodBind = ffi.metatype('godot_method_bind', {
+local MethodBind = ffi_metatype('godot_method_bind', {
 	--- Calls the method in `object`.
 	-- @function __call
 	-- @tparam Object object

--- a/src/godot_ffi.lua
+++ b/src/godot_ffi.lua
@@ -1411,20 +1411,12 @@ typedef struct godot_pluginscript_language_desc {
 	void (*profiling_frame)(godot_pluginscript_language_data *p_data);
 	godot_pluginscript_script_desc script_desc;
 } godot_pluginscript_language_desc;
-
-// Global API pointers
-const godot_gdnative_core_api_struct *hgdn_core_api;
-const godot_gdnative_core_1_1_api_struct *hgdn_core_1_1_api;
-const godot_gdnative_core_1_2_api_struct *hgdn_core_1_2_api;
-const godot_gdnative_core_1_3_api_struct *hgdn_core_1_3_api;
-godot_object *hgdn_library;
 ]]
 
-local pluginscript_callbacks, in_editor, active_library_path = ...
-local clib = active_library_path and ffi.load(active_library_path, true) or ffi.C
+local pluginscript_callbacks, in_editor, api, api_1_1, api_1_2, api_1_3, gdnativelibrary = ...
 
-local api = clib.hgdn_core_api
-local api_1_1 = clib.hgdn_core_1_1_api
-local api_1_2 = clib.hgdn_core_1_2_api
-local api_1_3 = clib.hgdn_core_1_3_api
-
+api = ffi.cast('godot_gdnative_core_api_struct *', api)
+api_1_1 = ffi.cast('godot_gdnative_core_1_1_api_struct *', api_1_1)
+api_1_2 = ffi.cast('godot_gdnative_core_1_2_api_struct *', api_1_2)
+api_1_3 = ffi.cast('godot_gdnative_core_1_3_api_struct *', api_1_3)
+gdnativelibrary = ffi.cast('godot_object *', gdnativelibrary)

--- a/src/godot_quat.lua
+++ b/src/godot_quat.lua
@@ -121,7 +121,7 @@ methods.IDENTITY = ffi_new('godot_quat', { elements = { 0, 0, 0, 1 } })
 
 --- Metamethods
 -- @section metamethods
-Quat = ffi.metatype('godot_quat', {
+Quat = ffi_metatype('godot_quat', {
 	--- Quat constructor, called by the idiom `Quat(...)`.
 	--
 	-- * `Quat()`: `IDENTITY` quaternion (`Quat() == Quat(0, 0, 0, 1)`)

--- a/src/godot_string_name.lua
+++ b/src/godot_string_name.lua
@@ -46,7 +46,7 @@ local methods = {
 	-- @return[type=const void *]
 	get_data_unique_pointer = api.godot_string_name_get_data_unique_pointer,
 }
-StringName = ffi.metatype('godot_string_name', {
+StringName = ffi_metatype('godot_string_name', {
 	--- StringName constructor, called by the idiom `StringName(name)`.
 	-- @function __new
 	-- @param[opt=""] name  Name, stringified with `GD.str`

--- a/src/language_gdnative.c
+++ b/src/language_gdnative.c
@@ -272,7 +272,7 @@ static void lps_instance_notification(godot_pluginscript_instance_data *data, in
 }
 
 // In-editor callbacks
-godot_string lps_get_template_source_code(godot_pluginscript_language_data *data, const godot_string *class_name, const godot_string *base_class_name) {
+static godot_string lps_get_template_source_code(godot_pluginscript_language_data *data, const godot_string *class_name, const godot_string *base_class_name) {
 	godot_string ret;
 	hgdn_core_api->godot_string_new(&ret);
 	LPS_PUSH_CALLBACK(lps_L, "get_template_source_code");
@@ -285,7 +285,7 @@ godot_string lps_get_template_source_code(godot_pluginscript_language_data *data
 	return ret;
 }
 
-godot_bool lps_validate(godot_pluginscript_language_data *data, const godot_string *script, int *line_error, int *col_error, godot_string *test_error, const godot_string *path, godot_pool_string_array *functions) {
+static godot_bool lps_validate(godot_pluginscript_language_data *data, const godot_string *script, int *line_error, int *col_error, godot_string *test_error, const godot_string *path, godot_pool_string_array *functions) {
 	LPS_PUSH_CALLBACK(lps_L, "validate");
 	lua_pushlightuserdata(lps_L, (void *) script);
 	lua_pushlightuserdata(lps_L, (void *) line_error);
@@ -302,7 +302,7 @@ godot_bool lps_validate(godot_pluginscript_language_data *data, const godot_stri
 	return success;
 }
 
-godot_string lps_make_function(godot_pluginscript_language_data *data, const godot_string *class_name, const godot_string *name, const godot_pool_string_array *args) {
+static godot_string lps_make_function(godot_pluginscript_language_data *data, const godot_string *class_name, const godot_string *name, const godot_pool_string_array *args) {
 	godot_string ret;
 	hgdn_core_api->godot_string_new(&ret);
 	LPS_PUSH_CALLBACK(lps_L, "make_function");
@@ -316,7 +316,7 @@ godot_string lps_make_function(godot_pluginscript_language_data *data, const god
 	return ret;
 }
 
-void lps_register_in_editor_callbacks(godot_pluginscript_language_desc *desc) {
+static void lps_register_in_editor_callbacks(godot_pluginscript_language_desc *desc) {
 	desc->get_template_source_code = &lps_get_template_source_code;
 	desc->validate = &lps_validate;
 	desc->make_function = &lps_make_function;

--- a/src/late_globals.lua
+++ b/src/late_globals.lua
@@ -35,7 +35,7 @@ GD = {
 	--- (`const godot_gdnative_core_1_2_api_struct *`) GDNative core API 1.2
 	api_1_2 = api_1_2,
 	--- (`Object`) [GDNativeLibrary](https://docs.godotengine.org/en/stable/classes/class_gdnativelibrary.html) instance
-	gdnativelibrary = clib.hgdn_library,
+	gdnativelibrary = gdnativelibrary,
 	--- `Enumerations.Error`
 	Error = Error,
 	--- `Enumerations.VariantType`

--- a/src/lua_object_wrapper.lua
+++ b/src/lua_object_wrapper.lua
@@ -26,7 +26,7 @@
 -- @module lua_object_wrapper
 -- @local
 
-local library_resource_dir = clib.hgdn_library.resource_path:get_base_dir()
+local library_resource_dir = gdnativelibrary.resource_path:get_base_dir()
 
 --- Global cache of Lua object wrappers
 local lps_lua_object_references = setmetatable({}, weak_kv)


### PR DESCRIPTION
This fixes #31, while also simplifying the initialization code.
Since we don't need to access exported symbols directly anymore, there is no need to find the active library path.