### PR TITLE
Fix mangled error message format

### DIFF
--- a/src/pluginscript_callbacks.lua
+++ b/src/pluginscript_callbacks.lua
@@ -61,7 +61,9 @@ local function print_coroutine_error(co, err, msg_prefix)
 		table_insert(msg_lines, table_concat(lps_callstack[i], ' '))
 	end
 	local msg = table_concat(msg_lines, '\n\tin ')
-	api.godot_print_error(msg, debug_getinfo(co, 0, 'n').name, filename, tonumber(line))
+	api.godot_print_error(
+		("%s:%d: %s"):format(filename, tonumber(line), msg:match("[%w%p%s]-%c"):gsub('%c', '', 1)), debug_getinfo(co, 0, 'n').name, filename, tonumber(line)
+	)
 end
 
 local function wrap_callback(f, error_return)

--- a/src/pluginscript_callbacks.lua
+++ b/src/pluginscript_callbacks.lua
@@ -54,16 +54,7 @@ local function print_coroutine_error(co, err, msg_prefix)
 	if not filename then
 		filename, line, err_msg = '?', -1, err
 	end
-	local msg_lines = {
-		(msg_prefix or '') .. debug_traceback(co, err_msg, 1),
-	}
-	for i = #lps_callstack, 1, -1 do
-		table_insert(msg_lines, table_concat(lps_callstack[i], ' '))
-	end
-	local msg = table_concat(msg_lines, '\n\tin ')
-	api.godot_print_error(
-		("%s:%d: %s"):format(filename, tonumber(line), msg:match("[%w%p%s]-%c"):gsub('%c', '', 1)), debug_getinfo(co, 0, 'n').name, filename, tonumber(line)
-	)
+	api.godot_print_error((msg_prefix or filename .. ':' .. line .. ': ') .. err_msg, debug_getinfo(co, 0, 'n').name, filename, tonumber(line))
 end
 
 local function wrap_callback(f, error_return)


### PR DESCRIPTION
When you get a Lua error in the Godot debugger, the error message includes newlines and control characters which get rendered as question mark symbols and make the message look mangled.

I just changed the error format to a simpler one-liner that will most likely fit on one's screen and not look broken.

Before and after:
![Before and after image](https://i.ibb.co/DYGXV5f/beforeandafter.png)

I have only tested this on Linux (linux64) but in theory it should work on all platforms.

Thank you for maintaining this project!